### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/Controller/LTIController.php
+++ b/Controller/LTIController.php
@@ -43,7 +43,7 @@ class LTIController extends Controller
         $oauthRequest = $this->IMSProvider->prepareLaunchRequest($parameters);
         $form = $this->IMSProvider->buildForm($oauthRequest);
 
-        return $this->render('LTIConsumerBundle::index.html.twig', ['form' => $form]);
+        return $this->render('@LTIConsumer/index.html.twig', ['form' => $form]);
     }
 
     /**

--- a/Resources/views/index.html.twig
+++ b/Resources/views/index.html.twig
@@ -1,8 +1,16 @@
 {{ form(form,{'attr': {'id': 'lti_form'}}) }}
 <p>{{ 'lti.launch.message'|trans }}</p>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<button type="submit" form="lti_form">{{ 'lti.launch.submit_now' }}</button>
 <script>
-    $(function() {
-        $('#lti_form').submit();
-    });
+    function submitForm() {
+        document.getElementById('lti_form').submit();
+    }
+
+    if (document.readyState !== 'loading') {
+        // Document is already ready, call the callback directly
+        submitForm();
+    } else if (document.addEventListener) {
+        // All modern browsers to register DOMContentLoaded
+        document.addEventListener('DOMContentLoaded', submitForm);
+    }
 </script>

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
 
     "require": {
-        "php": ">=8.0",
+        "php": ">=7.1.3",
         "symfony/framework-bundle": "4.4.*",
         "symfony/options-resolver": "4.4.*",
         "symfony/form": "4.4.*"

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
 
     "require": {
         "php": ">=7.1.3",
-        "symfony/framework-bundle": "4.4.*",
-        "symfony/options-resolver": "4.4.*",
-        "symfony/form": "4.4.*"
+        "symfony/framework-bundle": "~4.4",
+        "symfony/options-resolver": "^4.4",
+        "symfony/form": "^4.4"
     },
 
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     ],
 
     "require": {
-        "php": ">=5.6",
-        "symfony/framework-bundle": "~3.4",
-        "symfony/options-resolver": "^3.4",
-        "symfony/form": "^3.4"
+        "php": ">=8.0",
+        "symfony/framework-bundle": "4.4.*",
+        "symfony/options-resolver": "4.4.*",
+        "symfony/form": "4.4.*"
     },
 
     "config": {


### PR DESCRIPTION
This PR bumps the required version of Symfony from **3.4.x** to **4.4.x**.

It also removes the usage of jQuery in favour of plain JavaScript, and provides an alternative for users who have disabled JavaScript in the launch template.